### PR TITLE
Better architecture detection by listing images with the io.resin.architecture label set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+* Better device arch detection

--- a/logsetup.sh
+++ b/logsetup.sh
@@ -9,8 +9,16 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source ${DIR}/utils.sh
 
 IMAGE="resinplayground/logspout"
-ARCH=$(listImages | jq '.[0].Labels."io.resin.architecture"' | tr -d '"')
 LOGGING_SERVER=${LOGGING_SERVER:-"syslog+tcp://logstash.resin.io:5000"}
+
+ARCH=${ARCH:-$(listArchLabeledImages | jq '.[0].Labels."io.resin.architecture"' | tr -d '"')}
+if [ -z "$ARCH" ] || [ "$ARCH" = "null" ]; then
+	echo "Could not detect device architecture."
+	echo "Please run this script with ARCH environment variable set to match the architecture of this device."
+	exit 1
+fi
+
+echo "Detected architecture: ${ARCH}"
 
 function showHelp {
 	echo "This script is used to create and start a logspout container on the device"

--- a/utils.sh
+++ b/utils.sh
@@ -53,6 +53,7 @@ function __curl {
 
 	curl \
 		${extraCurlArgs} \
+		--globoff \
 		--silent \
 		-X "$method" \
 		-H "Content-Type: application/json" \
@@ -72,6 +73,9 @@ function listImages {
 	curlGetResponse "GET" "v1/images"
 }
 
+function listArchLabeledImages {
+	curlGetResponse "GET" "v1/images?filters={\"label\":[\"io.resin.architecture\"]}"
+}
 
 function listContainers {
 	curlGetResponse "GET" "v1/containers?all=1"


### PR DESCRIPTION
Fixes #1 

The solution was to try to find the architecture by checking the `io.resin.architecture` Label of docker images. If no image with that label is set, the script fails with a descriptive error message.
